### PR TITLE
feat: Add --out-file parameter to fetch

### DIFF
--- a/cmd/labrador/fetch.go
+++ b/cmd/labrador/fetch.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -114,6 +115,7 @@ func formatRecordsOutput(records map[string]*record.Record) string {
 
 // Write fetched, formatted values to file.
 func writeFormattedOutFile(formattedOutput string, outFilePath string) {
+	outFilePath = filepath.Clean(outFilePath)
 	fh, err := os.OpenFile(outFilePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		core.PrintFatal(err.Error(), 1)

--- a/cmd/labrador/fetch.go
+++ b/cmd/labrador/fetch.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -21,9 +22,18 @@ var fetchCmd = &cobra.Command{
 // Initialize the fetch CLI subcommand
 func init() {
 
+	// out-file
+	defaultOutFile := viper.GetViper().GetString(core.OptStr_OutFile)
+	fetchCmd.PersistentFlags().StringP("out-file", "o", defaultOutFile, "File path to write variable/value pairs to")
+	err := viper.BindPFlag(core.OptStr_OutFile, fetchCmd.PersistentFlags().Lookup(core.OptStr_OutFile))
+	if err != nil {
+		panic(err)
+	}
+
+	// aws-ps
 	defaultAwsSsmParameters := viper.GetViper().GetStringSlice(core.OptStr_AWS_SsmParameterStore)
 	fetchCmd.PersistentFlags().StringSlice("aws-ps", defaultAwsSsmParameters, "AWS SSM parameter store path prefix or ARN")
-	err := viper.BindPFlag(core.OptStr_AWS_SsmParameterStore, fetchCmd.PersistentFlags().Lookup(core.OptStr_AWS_SsmParameterStore))
+	err = viper.BindPFlag(core.OptStr_AWS_SsmParameterStore, fetchCmd.PersistentFlags().Lookup(core.OptStr_AWS_SsmParameterStore))
 	if err != nil {
 		panic(err)
 	}
@@ -31,7 +41,7 @@ func init() {
 	rootCmd.AddCommand(fetchCmd)
 }
 
-// Logic for the fetch CLI subcommand
+// Top level logic for the fetch CLI subcommand
 func fetch(cmd *cobra.Command, args []string) {
 	ShowBanner()
 
@@ -41,27 +51,21 @@ func fetch(cmd *cobra.Command, args []string) {
 
 	records := make(map[string]*record.Record, 0)
 
-	// Fetch values from AWs SSM Parameter Store if defined.
-	awsSsmParameters := viper.GetStringSlice(core.OptStr_AWS_SsmParameterStore)
-	if len(awsSsmParameters) != 0 {
-		ssmRecords, err := aws.FetchParameterStore()
-		if err != nil {
-			core.PrintFatal("failed to get SSM parameters", 1)
-		}
-		core.PrintVerbose(fmt.Sprintf("Fetched %d SSM parameters", len(ssmRecords)))
-
-		for name, record := range ssmRecords {
-			records[name] = record
-		}
-	}
-
-	envFormat, err := record.RecordsAsEnvFile(records)
-	if err != nil {
-		core.PrintFatal("failed to format records as env file", 1)
-	}
-	core.PrintNormal("\n")
-	core.PrintAlways(envFormat)
+	records = fetchAwsSsmParameters(records)
 	core.PrintNormal(fmt.Sprintf("\nFetched %d values\n", len(records)))
+
+	formattedOutput := formatRecordsOutput(records)
+
+	outFilePath := viper.GetString(core.OptStr_OutFile)
+	if outFilePath != "" {
+		// Dump formatted results to file.
+		writeFormattedOutFile(formattedOutput, outFilePath)
+		core.PrintNormal(fmt.Sprintf("Wrote parameters to file: %s\n", outFilePath))
+	} else {
+		// Display formatted results to STDOUT.
+		core.PrintAlways(formattedOutput)
+		core.PrintNormal("\n")
+	}
 }
 
 // Count the number of user-defined resources to pull values from.
@@ -72,4 +76,52 @@ func countRemoteTargets() int {
 	remoteTargetCount += len(awsSsmParameters)
 
 	return remoteTargetCount
+}
+
+// Fetch values, convert to records, add to list, and return the list.
+func fetchAwsSsmParameters(records map[string]*record.Record) map[string]*record.Record {
+
+	awsSsmParameters := viper.GetStringSlice(core.OptStr_AWS_SsmParameterStore)
+	if len(awsSsmParameters) != 0 {
+		ssmRecords, err := aws.FetchParameterStore()
+		if err != nil {
+			core.PrintFatal("failed to get SSM parameters", 1)
+		}
+
+		core.PrintVerbose(fmt.Sprintf("\nFetched %d SSM parameters", len(ssmRecords)))
+		for name, record := range ssmRecords {
+			records[name] = record
+			core.PrintVerbose(fmt.Sprintf("\n\t%s", record.Data["arn"]))
+			core.PrintDebug(fmt.Sprintf("\n\t\ttype: \t\t%s", record.Data["type"]))
+			core.PrintDebug(fmt.Sprintf("\n\t\tversion: \t%s", record.Data["version"]))
+			core.PrintDebug(fmt.Sprintf("\n\t\tmodified: \t%s", record.Data["last-modified"]))
+		}
+	}
+
+	return records
+}
+
+// Convert the list of records to formatted output.
+func formatRecordsOutput(records map[string]*record.Record) string {
+	// Only does env format for now.
+	formattedOutput, err := record.RecordsAsEnvFile(records)
+	if err != nil {
+		core.PrintFatal("failed to format records as env file", 1)
+	}
+
+	return formattedOutput
+}
+
+// Write fetched, formatted values to file.
+func writeFormattedOutFile(formattedOutput string, outFilePath string) {
+	fh, err := os.OpenFile(outFilePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+	if err != nil {
+		core.PrintFatal(err.Error(), 1)
+	}
+
+	defer fh.Close()
+
+	if _, err = fh.WriteString(formattedOutput); err != nil {
+		core.PrintFatal(err.Error(), 1)
+	}
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,6 +8,16 @@
 - A configured Golang development environment.
 - A configured Docker installation (optional).
 
+### Local Setup
+
+Copy the Git hook for `pre-push`, so that new code is linted and scanned
+before pushing to the remote.
+
+```sh
+cp scripts/pre-push .git/hooks/pre-push
+chmod 700 .git/hooks/pre-push
+```
+
 ### Building Only the Binary
 
 ```sh

--- a/docs/development.md
+++ b/docs/development.md
@@ -35,7 +35,7 @@ make install
 
 labrador version
 ```
-
+nothing
 ## Releasing
 
 ### Release Workflow Configuration
@@ -118,3 +118,17 @@ leading zeros.
 
 More information about adding documentation for a package can be found
 at: https://pkg.go.dev/about#adding-a-package
+
+
+## CLI Development
+
+### Adding a Subcommand CLI Parameter
+
+Files to modify:
+- `core/config.go`:
+  - Add a constant variable for the option's key in the Viper settings.
+  - Add a default option value to the Viper settings in the init code.
+- `cmd/labrador/<subcommand>.go`
+  - Add init code that gets the default value, defines the CLI parameter,
+      and fetches the user defined value for the option.
+

--- a/internal/aws/ssm_parameter_store.go
+++ b/internal/aws/ssm_parameter_store.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -24,9 +23,9 @@ func FetchParameterStore() (map[string]*record.Record, error) {
 	ssmParameterResources := viper.GetStringSlice(core.OptStr_AWS_SsmParameterStore)
 	ssmParameterRecords := make(map[string]*record.Record, 0)
 
-	core.PrintVerbose("\nFetching SSM parameters:")
+	core.PrintVerbose("\nFetching SSM parameters...")
 	for _, resource := range ssmParameterResources {
-		core.PrintVerbose(fmt.Sprintf("\n\t%s", resource))
+		core.PrintDebug(fmt.Sprintf("\n\t%s", resource))
 	}
 
 	// Fetch and aggregate the parameter resources.
@@ -42,8 +41,6 @@ func FetchParameterStore() (map[string]*record.Record, error) {
 
 // Initialize a SSM client.
 func initSsmClient() *ssm.Client {
-	//verbose := viper.GetBool(core.OptStr_Verbose)
-
 	// Using the SDK's default configuration, loading additional config
 	// and credentials values from the environment variables, shared
 	// credentials, and shared configuration files
@@ -121,36 +118,4 @@ func parameterToRecord(parameter *ssmTypes.Parameter) *record.Record {
 	result.Data["version"] = fmt.Sprintf("%d", parameter.Version)
 
 	return &result
-}
-
-// This isn't used right now. Scraps to use for later.
-func SsmToFile() {
-
-	OUTFILE := "test_out.txt"
-
-	m := make(map[string]string)
-
-	// Write parameters to file.
-	fh, err := os.OpenFile(OUTFILE, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
-	if err != nil {
-		panic(err)
-	}
-
-	defer fh.Close()
-
-	// Isolate variable name from full parameter store path.
-	// Then write it to file.
-	// TODO: separate the variable name extraction from file writing.
-	for full_key, value := range m {
-
-		split_key := strings.Split(full_key, "/")
-		var_name := split_key[len(split_key)-1]
-
-		line := fmt.Sprintf("%s=%s\n", var_name, value)
-		if _, err = fh.WriteString(line); err != nil {
-			panic(err)
-		}
-
-	}
-	core.PrintNormal(fmt.Sprintf("\nWrote parameters to file: %s\n", OUTFILE))
 }

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -38,6 +38,7 @@ func initRootDefaults() {
 // Fetch configuration options
 var (
 	OptStr_NoConflict = "no-conflict"
+	OptStr_OutFile    = "out-file"
 
 	OptStr_AWS_SsmParameterStore = "aws-ps"
 	OptStr_AWS_SecretManager     = "aws-sm"
@@ -45,6 +46,7 @@ var (
 
 func initFetchDefaults() {
 	viper.SetDefault(OptStr_NoConflict, false)
+	viper.SetDefault(OptStr_OutFile, "")
 
 	viper.SetDefault(OptStr_AWS_SsmParameterStore, nil)
 	viper.SetDefault(OptStr_AWS_SecretManager, nil)

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# .git/hooks/pre-push
+#
+# Git hook that runs before each push to remote.
+
+remote="$1"
+url="$2"
+
+make lint
+ret=$?
+if [ $ret -ne 0 ]; then
+  exit $ret;
+fi
+
+make sast
+ret=$?
+if [ $ret -ne 0 ]; then
+  exit $ret;
+fi


### PR DESCRIPTION
Add `--out-file <file>` parameter to the `fetch` subcommand. Passing the `$GITHUB_ENV` file path will make setting environment variables in Github Actions cleaner than using redirection with `>>`.