### PR TITLE
feat: add outfile permission arg to fetch

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -39,6 +39,7 @@ func initRootDefaults() {
 var (
 	OptStr_NoConflict = "no-conflict"
 	OptStr_OutFile    = "out-file"
+	OptStr_FileMode   = "out-file-mode"
 
 	OptStr_AWS_SsmParameterStore = "aws-ps"
 	OptStr_AWS_SecretManager     = "aws-sm"
@@ -47,6 +48,7 @@ var (
 func initFetchDefaults() {
 	viper.SetDefault(OptStr_NoConflict, false)
 	viper.SetDefault(OptStr_OutFile, "")
+	viper.SetDefault(OptStr_FileMode, "0600")
 
 	viper.SetDefault(OptStr_AWS_SsmParameterStore, nil)
 	viper.SetDefault(OptStr_AWS_SecretManager, nil)


### PR DESCRIPTION
This adds a `--out-file-mode` parameter to the `fetch` subcommand, so that the file permissions on a generated file can be configured. This is particularly helpful for Github Actions, where file permissions need to be adjusted inside running containers, in order to get the fetched values out.