### PR TITLE
feat: Fetch values from AWS Secrets Manager

### DIFF
--- a/.labrador.example.yaml
+++ b/.labrador.example.yaml
@@ -16,9 +16,9 @@ quiet: false
 # Option to write gathered variables/values to a file.
 outfile:
   # File path.
-  path: foobar.txt
+  path: local.env
   # File permisson mode.
-  mode: '760'
+  mode: '660'
 
 
 ###########################################################
@@ -26,6 +26,13 @@ outfile:
 ###########################################################
 
 aws:
+
+  # List of AWS Secrets Manager secret names to fetch.
+  # Each secret can hold multiple key/value pairs. All are pulled.
+  sm_secret:
+  - name/of/one
+  - name/of/two
+
   # List of AWS SSM Parameter Store paths to recursively fetch.
   # Each item can be a single param, or a wildcard path to pull all params.
   ssm_param:

--- a/README.md
+++ b/README.md
@@ -2,17 +2,21 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/divergentcodes/labrador.svg)](https://pkg.go.dev/github.com/divergentcodes/labrador)
 
-Pull secrets from remote services into CI/CD pipelines.
+Fetch variables and secrets from remote services.
 
-Labrador is a CLI tool to fetch variables and secrets from remote
-services. Values are recursively pulled from one or more services,
-and output to the terminal or a file.
+Labrador is a CLI tool to fetch variables and secrets from one or more
+remote services. Values are recursively pulled from services, and
+output to the terminal or a file.
 
 The primary use case is enabling secretless pipelines in
 conjunction with automated OIDC authentication to cloud providers,
 where secrets are dynamically fetched instead of statically stored.
 
-Additional CI/CD pipeline support:
+Supported remote stores:
+- AWS Secrets Manager
+- AWS SSM Parameter Store
+
+CI/CD pipeline packages:
 - [labrador-action](https://github.com/marketplace/actions/labrador-action):
     A Github action for pulling variables and secrets into workflows.
 
@@ -24,33 +28,28 @@ curl -sL https://github.com/DivergentCodes/labrador/releases/latest/download/lab
 ./labrador fetch --aws-param "/path/to/params/*" --outfile "local.env"
 ```
 
-You can also copy the example configuration file, `.labrador.example.yaml`
-over to `.labrador.yaml` and customize it.
+You can also copy the `.labrador.example.yaml` example configuration file
+over to `.labrador.yaml`, customize it, and run `labrador fetch` without
+any other arguments needed.
 
 
 ## Installation
 
-### Binary from Github Releases
-
-Download and run the binary CLI from Github releases.
+Install and run the compiled binary.
 
 ```sh
 curl -sL https://github.com/DivergentCodes/labrador/releases/latest/download/labrador_Linux_x86_64.tar.gz  | tar -zx
 labrador version
 ```
 
-### Docker from Github Container Registry
-
-Pull and run the Docker image from the Github container registry.
+Install and run the Docker container.
 
 ```sh
 docker pull ghcr.io/divergentcodes/labrador
 docker run -it --rm ghcr.io/divergentcodes/labrador version
 ```
 
-### Binary from Source
-
-Download and run the binary CLI from Github releases.
+Install and run from source.
 
 ```sh
 git clone https://github.com/DivergentCodes/labrador
@@ -65,9 +64,10 @@ All CLI arguments can also be configured as environment variables,
 prefixed with `LAB_`.
 
 Examples:
-- `LAB_VERBOSE=1`
+- `LAB_AWS_SM_SECRET=name/of/secret`
 - `LAB_AWS_SSM_PARAM=/base/path/to/params/*`
 - `LAB_OUT_FILE=file.env`
+- `LAB_VERBOSE=1`
 
 
 ### AWS Environment Variables

--- a/cmd/labrador/fetch.go
+++ b/cmd/labrador/fetch.go
@@ -40,7 +40,7 @@ func init() {
 		panic(err)
 	}
 
-	// aws-ssmps
+	// aws-param
 	defaultAwsSsmParameters := viper.GetViper().GetStringSlice(core.OptStr_AWS_SsmParameterStore)
 	fetchCmd.PersistentFlags().StringSlice("aws-param", defaultAwsSsmParameters, "AWS SSM parameter store path prefix or ARN")
 	err = viper.BindPFlag(core.OptStr_AWS_SsmParameterStore, fetchCmd.PersistentFlags().Lookup("aws-param"))

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/aws/aws-sdk-go-v2 v1.18.1
 	github.com/aws/aws-sdk-go-v2/config v1.18.27
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.19.10
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.6
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.3.35 h1:LWA+3kDM8ly001vJ1X1waCuLJdt
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.35/go.mod h1:0Eg1YjxE0Bhn56lx+SHJwCzhW+2JGtizsrx+lCqrfm0=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.28 h1:bkRyG4a929RCnpVSTvLM2j/T4ls015ZhhYApbmYs15s=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.28/go.mod h1:jj7znCIg05jXlaGBlFMGP8+7UN3VtCkRBG2spnmRQkU=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.19.10 h1:eW8zPSh7ZLzb7029xCsIEFbnxLvNHPTt7aWwdKjNJc8=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.19.10/go.mod h1:ezn6mzIRqTPdAbDpm03dx4y9g6rvGRb2q33wS76dCxw=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.36.6 h1:/DEPQUCqR6UoJjW4a21gW9AqjFlRSTwyOmciNef19qI=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.36.6/go.mod h1:NdyMyZH/FzmCaybTrVMBD0nTCGrs1G4cOPKHFywx9Ns=
 github.com/aws/aws-sdk-go-v2/service/sso v1.12.12 h1:nneMBM2p79PGWBQovYO/6Xnc2ryRMw3InnDJq1FHkSY=

--- a/internal/aws/secrets_manager.go
+++ b/internal/aws/secrets_manager.go
@@ -1,0 +1,135 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/spf13/viper"
+
+	"github.com/divergentcodes/labrador/internal/core"
+	"github.com/divergentcodes/labrador/internal/record"
+)
+
+// Fetch values from AWS Secrets Manager.
+func FetchSecretsManager() (map[string]*record.Record, error) {
+
+	smClient := initSecretsManagerClient()
+	secretsManagerResources := viper.GetStringSlice(core.OptStr_AWS_SecretManager)
+	secretsManagerRecords := make(map[string]*record.Record, 0)
+
+	core.PrintVerbose("\nFetching Secrets Manager values...")
+	for _, resource := range secretsManagerResources {
+		core.PrintDebug(fmt.Sprintf("\n\t%s", resource))
+	}
+
+	// Fetch and aggregate the parameter resources.
+	for _, resource := range secretsManagerResources {
+		smSecretsManagerResultBatch := fetchSecretsManagerSecret(smClient, resource)
+		for name, record := range smSecretsManagerResultBatch {
+			secretsManagerRecords[name] = record
+		}
+	}
+
+	return secretsManagerRecords, nil
+}
+
+func initSecretsManagerClient() *secretsmanager.Client {
+	// Using the SDK's default configuration, loading additional config
+	// and credentials values from the environment variables, shared
+	// credentials, and shared configuration files
+	awsConfig, err := config.LoadDefaultConfig(
+		context.TODO(),
+		//config.WithRegion(region),
+	)
+	if err != nil {
+		log.Fatalf("unable to load AWS SDK config, %v", err)
+	}
+
+	core.PrintVerbose("\nInitializing AWS Secrets Manager client...")
+	smClient := secretsmanager.NewFromConfig(awsConfig)
+	if err != nil {
+		log.Fatalf("failed to initialize AWS Secrets Manager client, %v", err)
+	}
+
+	return smClient
+}
+
+// Fetch a secret from AWS Secrets Manager.
+func fetchSecretsManagerSecret(smClient *secretsmanager.Client, resource string) map[string]*record.Record {
+	// Using a map to be consistent with the wilcard fetching.
+	smSecretResults := make(map[string]*record.Record, 0)
+
+	input := &secretsmanager.GetSecretValueInput{
+		SecretId:     aws.String(resource),
+		VersionStage: aws.String("AWSCURRENT"), // VersionStage defaults to AWSCURRENT if unspecified
+	}
+
+	resp, err := smClient.GetSecretValue(context.TODO(), input)
+	if err != nil {
+		log.Fatalf("failed to fetch AWS Secrets Manager values, %v", err)
+	}
+
+	smSecretResults = secretToRecords(resp, smSecretResults)
+
+	return smSecretResults
+}
+
+// Convert an AWS Secrets Manager secret to a list of Records.
+//
+// One secret can hold multiple key/value pairs.
+func secretToRecords(secret *secretsmanager.GetSecretValueOutput, smSecretRecords map[string]*record.Record) map[string]*record.Record {
+
+	var varType string
+	if secret.SecretString != nil {
+		varType = "SecretString"
+
+		// Extract key/value pairs from JSON.
+		var secretDict map[string]string
+		err := json.Unmarshal([]byte(*secret.SecretString), &secretDict)
+		if err != nil {
+			core.PrintFatal(err.Error(), 1)
+		}
+
+		// Format each key/value pair as a record.
+		for k, v := range secretDict {
+			result := record.Record{
+				Source:   "aws-secrets-manager",
+				Key:      k,
+				Value:    v,
+				Metadata: make(map[string]string),
+			}
+			result.Metadata["arn"] = *secret.ARN
+			result.Metadata["secret-name"] = *secret.Name
+			result.Metadata["type"] = varType
+			result.Metadata["created-date"] = secret.CreatedDate.String()
+			result.Metadata["version-id"] = *secret.VersionId
+			//result.Metadata["version-stages"] = *&secret.VersionStages[]
+
+			smSecretRecords[k] = &result
+		}
+	} else {
+		varType = "SecretBinary"
+
+		result := record.Record{
+			Source:   "aws-secrets-manager",
+			Key:      *secret.Name,
+			Value:    string(secret.SecretBinary[:]),
+			Metadata: make(map[string]string),
+		}
+		result.Metadata["arn"] = *secret.ARN
+		result.Metadata["secret-name"] = *secret.Name
+		result.Metadata["type"] = varType
+		result.Metadata["created-date"] = secret.CreatedDate.String()
+		result.Metadata["version-id"] = *secret.VersionId
+		//result.Metadata["version-stages"] = *&secret.VersionStages[]
+
+		smSecretRecords[*secret.Name] = &result
+	}
+
+	return smSecretRecords
+}

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -42,7 +42,7 @@ var (
 	OptStr_FileMode   = "outfile.mode"
 
 	OptStr_AWS_SsmParameterStore = "aws.ssm_param"
-	OptStr_AWS_SecretManager     = "aws.sm_secret"
+	OptStr_AWS_SecretManager     = "aws.sm_secret" //#nosec
 )
 
 func initFetchDefaults() {

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -42,7 +42,7 @@ var (
 	OptStr_FileMode   = "outfile.mode"
 
 	OptStr_AWS_SsmParameterStore = "aws.ssm_param"
-	OptStr_AWS_SecretManager     = "aws.sm"
+	OptStr_AWS_SecretManager     = "aws.sm_secret"
 )
 
 func initFetchDefaults() {

--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -12,5 +12,5 @@ type Record struct {
 	Source string
 
 	// Additional attributes about this record that might be useful.
-	Data map[string]string
+	Metadata map[string]string
 }


### PR DESCRIPTION
Support fetching values from AWS Secrets Manager.
- CLI flag: `--aws-secret`
- Env var: `LAB_AWS_SM_SECRET`
- Config file: `aws.sm_secret`

A single secret stores a set of key/value pairs, which are returned as a string map. Each key/value pair is set as its own variable.