### PR TITLE
feat: add config option for explicit AWS region

### DIFF
--- a/.labrador.example.yaml
+++ b/.labrador.example.yaml
@@ -27,6 +27,10 @@ outfile:
 
 aws:
 
+  # Explicitly set the AWS region. This can also be set with the
+  # standard AWS environment variables, or a CLI option.
+  #region: us-east-1
+
   # List of AWS Secrets Manager secret names to fetch.
   # Each secret can hold multiple key/value pairs. All are pulled.
   sm_secret:

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ configure some of these variables automatically, like the
 [aws-actions/configure-aws-credentials](https://github.com/marketplace/actions/configure-aws-credentials-for-github-actions)
 Github Action.
 
-The AWS region always needs to be defined.
+The AWS region always needs to be defined. It can also be set as a CLI
+argument or in the configuration file.
 - `AWS_REGION`
 
 Authenticating to AWS can be done using a profile, an API key, or an assumed role.

--- a/cmd/labrador/fetch.go
+++ b/cmd/labrador/fetch.go
@@ -40,6 +40,14 @@ func init() {
 		panic(err)
 	}
 
+	// aws-region
+	defaultAwsRegion := ""
+	fetchCmd.PersistentFlags().String("aws-region", defaultAwsRegion, "AWS region")
+	err = viper.BindPFlag(core.OptStr_AWS_Region, fetchCmd.PersistentFlags().Lookup("aws-region"))
+	if err != nil {
+		panic(err)
+	}
+
 	// aws-param
 	defaultAwsSsmParameters := viper.GetViper().GetStringSlice(core.OptStr_AWS_SsmParameterStore)
 	fetchCmd.PersistentFlags().StringSlice("aws-param", defaultAwsSsmParameters, "AWS SSM parameter store path prefix")

--- a/internal/aws/secrets_manager.go
+++ b/internal/aws/secrets_manager.go
@@ -39,15 +39,20 @@ func FetchSecretsManager() (map[string]*record.Record, error) {
 }
 
 func initSecretsManagerClient() *secretsmanager.Client {
+	awsRegion := viper.GetString(core.OptStr_AWS_Region)
+
 	// Using the SDK's default configuration, loading additional config
 	// and credentials values from the environment variables, shared
 	// credentials, and shared configuration files
 	awsConfig, err := config.LoadDefaultConfig(
 		context.TODO(),
-		//config.WithRegion(region),
 	)
 	if err != nil {
 		log.Fatalf("unable to load AWS SDK config, %v", err)
+	}
+	if awsRegion != "" {
+		awsConfig.Region = awsRegion
+		core.PrintDebug(fmt.Sprintf("\nSet AWS region: %s", awsRegion))
 	}
 
 	core.PrintVerbose("\nInitializing AWS Secrets Manager client...")

--- a/internal/aws/ssm_parameter_store.go
+++ b/internal/aws/ssm_parameter_store.go
@@ -51,6 +51,8 @@ func FetchParameterStore() (map[string]*record.Record, error) {
 
 // Initialize a SSM client.
 func initSsmClient() *ssm.Client {
+	awsRegion := viper.GetString(core.OptStr_AWS_Region)
+
 	// Using the SDK's default configuration, loading additional config
 	// and credentials values from the environment variables, shared
 	// credentials, and shared configuration files
@@ -59,6 +61,10 @@ func initSsmClient() *ssm.Client {
 	)
 	if err != nil {
 		log.Fatalf("unable to load AWS SDK config, %v", err)
+	}
+	if awsRegion != "" {
+		awsConfig.Region = awsRegion
+		core.PrintDebug(fmt.Sprintf("\nSet AWS region: %s", awsRegion))
 	}
 
 	core.PrintVerbose("\nInitializing AWS SSM client...")

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -41,6 +41,7 @@ var (
 	OptStr_OutFile    = "outfile.path"
 	OptStr_FileMode   = "outfile.mode"
 
+	OptStr_AWS_Region            = "aws.region"
 	OptStr_AWS_SsmParameterStore = "aws.ssm_param"
 	OptStr_AWS_SecretManager     = "aws.sm_secret" //#nosec
 )
@@ -50,6 +51,7 @@ func initFetchDefaults() {
 	viper.SetDefault(OptStr_OutFile, "")
 	viper.SetDefault(OptStr_FileMode, "0600")
 
+	viper.SetDefault(OptStr_AWS_Region, nil)
 	viper.SetDefault(OptStr_AWS_SsmParameterStore, nil)
 	viper.SetDefault(OptStr_AWS_SecretManager, nil)
 }


### PR DESCRIPTION
Add a configuration option for setting an explicit AWS region, separately from the standard `AWS_REGION` environment variable.