### PR TITLE
feat: support alternate config files

### DIFF
--- a/cmd/labrador/fetch.go
+++ b/cmd/labrador/fetch.go
@@ -79,7 +79,9 @@ func fetch(cmd *cobra.Command, args []string) {
 
 	records = fetchAwsSsmParameters(records)
 	records = fetchAwsSmSecrets(records)
+	core.PrintDebug("\n")
 	core.PrintNormal(fmt.Sprintf("\nFetched %d values\n", len(records)))
+	core.PrintDebug("\n")
 
 	formattedOutput := formatRecordsOutput(records)
 

--- a/cmd/labrador/root.go
+++ b/cmd/labrador/root.go
@@ -1,12 +1,11 @@
 /*
 Labrador fetches variables and secrets from remote services.
 
-Values are recursively pulled from one or more services, and output
-to the terminal or a file.
+Values are recursively pulled from one or more services, and output to the
+terminal or a file.
 
-Labrador is focused on reading and pulling values, not on managing
-or writing values. It was created with CI/CD pipelines and network
-services in mind.
+Labrador is focused on reading and pulling values, not on managing or writing
+values. It was created with CI/CD pipelines and network services in mind.
 
 Usage:
 
@@ -25,6 +24,8 @@ Flags:
 	-h, --help      help for labrador
 	-q, --quiet     Quiet CLI output
 	    --verbose   Verbose CLI output
+
+Use "labrador [command] --help" for more information about a command.
 */
 package cmd
 
@@ -54,10 +55,15 @@ values. It was created with CI/CD pipelines and network services in mind.`,
 
 // Run for root command. Will execute for all subcommands.
 func init() {
+	cobra.OnInitialize(core.InitConfigInstance)
 	initRootFlags()
 }
 
 func initRootFlags() {
+
+	// config
+	rootCmd.PersistentFlags().StringP("config", "c", "", "config file (default is .labrador.yaml)")
+	viper.BindPFlag(core.OptStr_Config, rootCmd.PersistentFlags().Lookup("config"))
 
 	// debug
 	defaultDebug := viper.GetBool(core.OptStr_Debug)
@@ -66,17 +72,6 @@ func initRootFlags() {
 	if err != nil {
 		panic(err)
 	}
-
-	// json
-	// TODO: implement exporting results to JSON.
-	/*
-		defaultOutJSON := viper.GetBool(core.OptStr_OutJSON)
-		rootCmd.PersistentFlags().Bool("json", defaultOutJSON, "Use JSON output")
-		err = viper.BindPFlag(core.OptStr_OutJSON, rootCmd.PersistentFlags().Lookup("json"))
-		if err != nil {
-			panic(err)
-		}
-	*/
 
 	// quiet
 	defaultQuiet := viper.GetBool(core.OptStr_Quiet)
@@ -93,6 +88,20 @@ func initRootFlags() {
 	if err != nil {
 		panic(err)
 	}
+
+	// json
+	// TODO: implement exporting results to JSON.
+	/*
+		defaultOutJSON := viper.GetBool(core.OptStr_OutJSON)
+		rootCmd.PersistentFlags().Bool("json", defaultOutJSON, "Use JSON output")
+		err = viper.BindPFlag(core.OptStr_OutJSON, rootCmd.PersistentFlags().Lookup("json"))
+		if err != nil {
+			panic(err)
+		}
+	*/
+
+	rootCmd.MarkFlagsMutuallyExclusive("quiet", "debug")
+	rootCmd.MarkFlagsMutuallyExclusive("quiet", "verbose")
 }
 
 // Execute starts the app CLI.

--- a/cmd/labrador/root.go
+++ b/cmd/labrador/root.go
@@ -20,10 +20,11 @@ Available Commands:
 
 Flags:
 
-	    --debug     Enable debug mode
-	-h, --help      help for labrador
-	-q, --quiet     Quiet CLI output
-	    --verbose   Verbose CLI output
+	-c, --config string   config file (default is .labrador.yaml)
+	    --debug           Enable debug mode
+	-h, --help            help for labrador
+	-q, --quiet           Quiet CLI output
+	    --verbose         Verbose CLI output
 
 Use "labrador [command] --help" for more information about a command.
 */
@@ -63,12 +64,15 @@ func initRootFlags() {
 
 	// config
 	rootCmd.PersistentFlags().StringP("config", "c", "", "config file (default is .labrador.yaml)")
-	viper.BindPFlag(core.OptStr_Config, rootCmd.PersistentFlags().Lookup("config"))
+	err := viper.BindPFlag(core.OptStr_Config, rootCmd.PersistentFlags().Lookup("config"))
+	if err != nil {
+		panic(err)
+	}
 
 	// debug
 	defaultDebug := viper.GetBool(core.OptStr_Debug)
 	rootCmd.PersistentFlags().Bool("debug", defaultDebug, "Enable debug mode")
-	err := viper.BindPFlag(core.OptStr_Debug, rootCmd.PersistentFlags().Lookup("debug"))
+	err = viper.BindPFlag(core.OptStr_Debug, rootCmd.PersistentFlags().Lookup("debug"))
 	if err != nil {
 		panic(err)
 	}

--- a/internal/aws/secrets_manager.go
+++ b/internal/aws/secrets_manager.go
@@ -38,6 +38,7 @@ func FetchSecretsManager() (map[string]*record.Record, error) {
 	return secretsManagerRecords, nil
 }
 
+// Initialize a AWS Secrets Manager client instance.
 func initSecretsManagerClient() *secretsmanager.Client {
 	awsRegion := viper.GetString(core.OptStr_AWS_Region)
 
@@ -55,6 +56,7 @@ func initSecretsManagerClient() *secretsmanager.Client {
 		core.PrintDebug(fmt.Sprintf("\nSet AWS region: %s", awsRegion))
 	}
 
+	core.PrintDebug("\n")
 	core.PrintVerbose("\nInitializing AWS Secrets Manager client...")
 	smClient := secretsmanager.NewFromConfig(awsConfig)
 	if err != nil {


### PR DESCRIPTION
- Add `--config` (`-c`) CLI argument for alternate, explicit configuration files.
- Allow paths to be set using relative or absolute path.
- Only raise "file not found" error if the config file was explicitly defined. Not on default.
- Separate initialization of config defaults and the initialization of the config instance.