### PR TITLE
feat: add quote flag

### DIFF
--- a/cmd/labrador/fetch.go
+++ b/cmd/labrador/fetch.go
@@ -40,6 +40,14 @@ func init() {
 		panic(err)
 	}
 
+	// quote
+	defaultQuote := viper.GetBool(core.OptStr_Quote)
+	fetchCmd.PersistentFlags().Bool("quote", defaultQuote, "Surround each value with doublequotes")
+	err = viper.BindPFlag(core.OptStr_Quote, fetchCmd.PersistentFlags().Lookup("quote"))
+	if err != nil {
+		panic(err)
+	}
+
 	// aws-region
 	defaultAwsRegion := ""
 	fetchCmd.PersistentFlags().String("aws-region", defaultAwsRegion, "AWS region")
@@ -161,7 +169,8 @@ func fetchAwsSmSecrets(variables map[string]*variable.Variable) map[string]*vari
 // Convert the list of variables to formatted output.
 func formatVariablesOutput(variables map[string]*variable.Variable) string {
 	// Only does env format for now.
-	formattedOutput, err := variable.VariablesAsEnvFile(variables)
+	useQuotes := viper.GetBool(core.OptStr_Quote)
+	formattedOutput, err := variable.VariablesAsEnvFile(variables, useQuotes)
 	if err != nil {
 		core.PrintFatal("failed to format variables as env file", 1)
 	}

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -41,6 +41,7 @@ var (
 	OptStr_NoConflict = "no-conflict"
 	OptStr_OutFile    = "outfile.path"
 	OptStr_FileMode   = "outfile.mode"
+	OptStr_Quote      = "quote"
 
 	OptStr_AWS_Region            = "aws.region"
 	OptStr_AWS_SsmParameterStore = "aws.ssm_param"
@@ -51,6 +52,7 @@ func initFetchDefaults() {
 	viper.SetDefault(OptStr_NoConflict, false)
 	viper.SetDefault(OptStr_OutFile, "")
 	viper.SetDefault(OptStr_FileMode, "0600")
+	viper.SetDefault(OptStr_Quote, false)
 
 	viper.SetDefault(OptStr_AWS_Region, nil)
 	viper.SetDefault(OptStr_AWS_SsmParameterStore, nil)

--- a/internal/variable/formats.go
+++ b/internal/variable/formats.go
@@ -21,7 +21,7 @@ func VariablesAsEnvFile(variables map[string]*Variable, quote bool) (string, err
 			envVarValue = escapeDoubleQuotes(envVarValue)
 			envVarValue = fmt.Sprintf("\"%s\"\n", envVarValue)
 		}
-		result += fmt.Sprintf("%s=%s\n", envVarName, envVarValue)
+		result += fmt.Sprintf("%s=%s", envVarName, envVarValue)
 	}
 
 	return result, nil

--- a/internal/variable/formats.go
+++ b/internal/variable/formats.go
@@ -10,16 +10,27 @@ import (
 // Format a set of variables as an env file.
 //
 //	export $(labrador --quiet | xargs)
-func VariablesAsEnvFile(variables map[string]*Variable) (string, error) {
+func VariablesAsEnvFile(variables map[string]*Variable, quote bool) (string, error) {
 
 	result := ""
 
 	for name, item := range variables {
 		envVarName := envNamify(name)
-		result += fmt.Sprintf("%s=%s\n", envVarName, item.Value)
+		envVarValue := item.Value
+		if quote {
+			envVarValue = escapeDoubleQuotes(envVarValue)
+			envVarValue = fmt.Sprintf("\"%s\"\n", envVarValue)
+		}
+		result += fmt.Sprintf("%s=%s\n", envVarName, envVarValue)
 	}
 
 	return result, nil
+}
+
+// Escape double quotes in provided string.
+func escapeDoubleQuotes(value string) string {
+	envVarValue := strings.Replace(value, "\"", "\\\"", -1)
+	return envVarValue
 }
 
 // Transform strings into valid environment variable names.


### PR DESCRIPTION
Add a `--quote` flag to the `fetch` subcommand, to surround each value in double quotes, and escape existing double quotes in the value.