### PR TITLE
feat: add export subcommand

### DIFF
--- a/.labrador.example.yaml
+++ b/.labrador.example.yaml
@@ -13,6 +13,9 @@ verbose: true
 # Only show the final result, without the banner or info.
 quiet: false
 
+# Surround values in double quotes and escape existing double quotes.
+quote: false
+
 # Option to write gathered variables/values to a file.
 outfile:
   # File path.

--- a/README.md
+++ b/README.md
@@ -2,35 +2,101 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/divergentcodes/labrador.svg)](https://pkg.go.dev/github.com/divergentcodes/labrador)
 
-Fetch variables and secrets from remote services.
+Labrador is a CLI tool to fetch secrets and other configuration values
+from one or more remote services.
 
-Labrador is a CLI tool to fetch variables and secrets from one or more
-remote services. Values are recursively pulled from services, and
-output to the terminal or a file.
+Labrador was created to explore safer, consistent, cross-platform ways of
+handling secrets during each phase of the SDLC. The idea is to fetch secrets
+from a central service at runtime, in a standard way, instead of copying secrets
+to each environment and persisting them all over the place.
 
-The primary use case is enabling secretless pipelines in
-conjunction with automated OIDC authentication to cloud providers,
-where secrets are dynamically fetched instead of statically stored.
+Example use cases:
+- Secretless pipelines, where zero static secrets are stored in CI providers/pipelines
+  (e.g. Github Actions, CircleCI, Jenkins, etc). Many CI providers support OIDC to
+  cloud providers, so that not even cloud credentials need to be stored in pipelines.
+- Smooth local development setup for projects, where one command sets up the
+  environment configuration, instead of instructions with copy/paste steps.
+  Developers can be sure that they are getting the latest configuration values.
+- Modular app configuration, where each environment can combine an individual set of
+  configuration values with another globally shared set of values.
+- Portable app configuration, where secrets are fetched during runtime in the same
+  way, regardless of the platform specifics.
 
-Supported remote stores:
-- AWS Secrets Manager
-- AWS SSM Parameter Store
 
-CI/CD pipeline packages:
-- [labrador-action](https://github.com/marketplace/actions/labrador-action):
-    A Github action for pulling variables and secrets into workflows.
+## Contents
 
+- [Quickstart](#quickstart)
+- [Features](#features)
+  - [Supported Value Stores](#supported-value-stores)
+  - [CI/CD Pipeline Packages](#cicd-pipeline-packages)
+- [Installation](#installation)
+- [Example Usage](#example-usage)
+  - [Fetch All AWS SSM Parameter Store Values at Given Base Path (Wildcard)](#fetch-all-aws-ssm-parameter-store-values-at-given-base-path-wildcard)
+  - [Fetch Two Sets of AWS SSM Parameter Store Values](#fetch-two-sets-of-aws-ssm-parameter-store-values)
+  - [Fetch an AWS Secrets Manager Value with multiple Key/Value Pairs](#fetch-an-aws-secrets-manager-value-with-multiple-keyvalue-pairs)
+  - [Fetch from Multiple Services At Once](#fetch-from-multiple-services-at-once)
+  - [Save Fetched Values to an `.env` File](#save-fetched-values-to-an-env-file)
+  - [Set Fetched Values as Environment Variables in the Current Shell](#set-fetched-values-as-environment-variables-in-the-current-shell)
+  - [Use a Portable Config File for Consistent Value Fetching](#use-a-portable-config-file-for-consistent-value-fetching)
+  - [Use Different Config Files for Local Development and CI/CD](#use-different-config-files-for-local-development-and-cicd)
+- [Reference](#reference)
+  - [Labrador Environment Variables](#labrador-environment-variables)
+  - [AWS Environment Variables](#aws-environment-variables)
+- [Why Go (Golang)?](#why-go-golang)
+- [Similar Projects](#similar-projects)
 
 ## Quickstart
 
+Before running, set environment variables for accessing the services where the
+values are stored.
+For example, if [authenticating to AWS](#aws-environment-variables) using a
+local profile:
+
+```sh
+export AWS_PROFILE="myprofile"
+export AWS_REGION="us-east-1"
+```
+
+Continuing the example, fetch all key/value pairs from AWS SSM Parameter Store
+at base path `/path/to/params/*`, and saving to the local file `.env`.
+
 ```sh
 curl -sL https://github.com/DivergentCodes/labrador/releases/latest/download/labrador_Linux_x86_64.tar.gz  | tar -zx
-./labrador fetch --aws-param "/path/to/params/*" --outfile "local.env"
+
+./labrador fetch --aws-param "/path/to/params/*" --outfile ".env"
 ```
 
 You can also copy the `.labrador.example.yaml` example configuration file
 over to `.labrador.yaml`, customize it, and run `labrador fetch` without
 any other arguments needed.
+
+## Features
+
+- **Configuration files**: Using an optional `.labrador.yaml` file, you
+  can load all required environment variables with a single command.
+  The file is portable and consistent across CI providers, environments,
+  and anywhere that Labrador can run. Use alternate config files for local
+  development, pipelines, and deployed environments.
+- **Output options**: Use fetched values to create an `.env` file, set
+  environment variables directly in the current shell, pass to another command,
+  or print to the console.
+- **Wildcard paths**: For supported value stores, use a single wildcard resource
+  path to recursively load all child values into the workflow
+  ([example](#fetch-multiple-values-from-ssm-parameter-store-using-wildcard-paths)).
+- **Multi-system fetching**: Labrador will pull from multiple remote stores in a
+  single run. This can alleviate infrastructure migrations, multi-team situations,
+  and other "real world quirks." Pulled values are coerced into a canonical format.
+
+
+### Supported Value Stores
+
+- **AWS SSM Parameter Store**: this action can pull individual parameters, or recursively pull a wildcard path with all child variables, as individual environment variables.
+- **AWS Secrets Manager**: this action can pull all key/value pairs in a single secret are loaded as individual environment variables.
+
+### CI/CD pipeline Packages
+
+- [labrador-action](https://github.com/marketplace/actions/labrador-action):
+    A Github action for pulling variables and secrets into workflows.
 
 
 ## Installation
@@ -57,8 +123,140 @@ cd labrador
 make install
 labrador version
 ```
+## Example Usage
 
-## Environment Variables
+### Fetch All AWS SSM Parameter Store Values at Given Base Path (Wildcard)
+
+Instead of declaring each parameter individually, just point to a base path
+and recursively fetch all child values. Add, update, or delete parameters in
+AWS, without needing any environment configuration changes.
+
+```sh
+labrador fetch --aws-param "/path/to/params/*"
+```
+
+### Fetch Two Sets of AWS SSM Parameter Store Values
+
+You can split configuration up into multiple sets of values, each with different
+IAM permissions.
+
+For instance, one base path in AWS Parameter Store can contain shared configuration
+used across all environments, while another base path has parameters for a
+specific instance.
+
+```sh
+labrador fetch --aws-param "/global/shared/params/*" --aws-param "/instance/params/*"
+```
+
+### Fetch an AWS Secrets Manager Value with multiple Key/Value Pairs
+
+A single secret in AWS Secrets Manager can store multiple key/value pairs.
+Labrador will pull the secret, extract each key/value, and return them as
+individual variables.
+
+```sh
+labrador fetch --aws-secret "path/to/secret"
+```
+
+### Fetch from Multiple Services At Once
+
+If your configuration is spread across multiple services (e.g. undergoing
+a migration), you can fetch values from all of them at the same time.
+
+```sh
+labrador fetch --aws-param "/path/to/params/*" --aws-secret "path/to/secret"
+```
+
+### Save Fetched Values to an `.env` File
+
+An [`.env` file](https://www.dotenv.org/docs/security/env.html)
+is useful for ergonomically defining environment variables in development,
+with tooling like
+[Docker](https://docs.docker.com/compose/environment-variables/env-file/)
+and [dotenv](https://www.npmjs.com/package/dotenv).
+
+```sh
+labrador fetch --aws-param "/path/to/params/*" --outfile ".env"
+```
+
+### Set Fetched Values as Environment Variables in the Current Shell
+
+This example assumes a `.labrador.yaml` configuration file exists in the current
+working directory.
+
+```sh
+source <(labrador export)
+```
+
+### Use a Portable Config File for Consistent Value Fetching
+
+Instead of each developer manually setting development variables as a setup step
+for a project, just have them run Labrador to pull dev values from a centralized
+store. Values can be updated/rotated in the remote store and be instantly available
+to all developers, removing tedious and error prone configuration changes.
+
+These configuration files can safely be committed to the repository, providing
+easier project setup for N developers, easier value updates, and no secrets stored
+on developer machines.
+
+```yaml
+# .labrador.yaml
+aws:
+  region: us-east-1
+  sm_secret:
+  - app/dev/values
+```
+
+```sh
+labrador fetch
+```
+
+
+### Use Different Config Files for Local Development and CI/CD
+
+You can use separate configuration files per environment, to keep secrets and
+configuration settings isolated, consistent, canonical, and reusable. Continue
+to control access
+
+Create one configuration file that will pull all needed values for local development.
+
+```yaml
+# .labrador.dev.yaml
+aws:
+  region: us-east-1
+  ssm_param:
+  - /app/shared/values/*
+  - /app/dev/values/*
+```
+
+Create a second configuration file that will pull all needed values for builds in the pipeline.
+
+```yaml
+# .labrador.ci.yaml
+aws:
+  region: us-east-1
+  ssm_param:
+  - /app/shared/values/*
+  - /app/ci/values/*
+```
+
+Run the development configuration to pull values needed for local development.
+
+```sh
+source <(labrador export --config .labrador.dev.yaml)
+```
+
+In the pipeline, run the CI configuration to pull values needed for builds or
+deployments.
+
+```sh
+labrador fetch --config .labrador.ci.yaml
+```
+
+
+## Reference
+
+### Labrador Environment Variables
 
 All CLI arguments can also be configured as environment variables,
 prefixed with `LAB_`.
@@ -89,3 +287,24 @@ session with AWS, like Github Actions' `aws-actions/configure-aws-credentials`.
 - `AWS_PROFILE`
 - `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID`
 - `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_SESSION_NAME`.
+
+
+## Why Go (Golang)?
+
+- Golang has official SDKs for most popular cloud platforms and value stores.
+- A single binary release results in simpler distribution, smaller artifacts, and more versitile usage.
+- The [Cobra](https://github.com/spf13/cobra) and [Viper](https://github.com/spf13/viper) packages are excellent for creating CLI tools.
+
+
+## Similar Projects
+
+- [segmentio/chamber](https://github.com/segmentio/chamber):
+  CLI tool to fetch from AWS SSM Parameter Store.
+- [hashicorp/vault-action](https://github.com/hashicorp/vault-action): Github
+  Action to fetch from Hashicorp Vault.
+- [aws-actions/aws-secretsmanager-get-secrets](https://github.com/aws-actions/aws-secretsmanager-get-secrets):
+  Github Action to fetch from AWS Secrets Manager.
+- [google-github-actions/get-secretmanager-secrets](https://github.com/google-github-actions/get-secretmanager-secrets):
+  Github Action to fetch from GCP Secret Manager.
+- [dotenv-org/dotenv-vault](https://github.com/dotenv-org/dotenv-vault):
+  File based value storage that uses Dotenv's servers for synchronizing.

--- a/cmd/labrador/export.go
+++ b/cmd/labrador/export.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/divergentcodes/labrador/internal/core"
+	"github.com/divergentcodes/labrador/internal/variable"
+)
+
+var exportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "Fetch and export values as shell environment variables",
+	Long:  "Fetch and export values as shell environment variables",
+	Run:   export,
+}
+
+// Initialize the fetch CLI subcommand
+func init() {
+
+	// aws-region
+	defaultAwsRegion := ""
+	exportCmd.PersistentFlags().String("aws-region", defaultAwsRegion, "AWS region")
+	err := viper.BindPFlag(core.OptStr_AWS_Region, exportCmd.PersistentFlags().Lookup("aws-region"))
+	if err != nil {
+		panic(err)
+	}
+
+	// aws-param
+	defaultAwsSsmParameters := viper.GetViper().GetStringSlice(core.OptStr_AWS_SsmParameterStore)
+	exportCmd.PersistentFlags().StringSlice("aws-param", defaultAwsSsmParameters, "AWS SSM parameter store path prefix")
+	err = viper.BindPFlag(core.OptStr_AWS_SsmParameterStore, exportCmd.PersistentFlags().Lookup("aws-param"))
+	if err != nil {
+		panic(err)
+	}
+
+	// aws-secret
+	defaultAwsSmSecrets := viper.GetViper().GetStringSlice(core.OptStr_AWS_SecretManager)
+	exportCmd.PersistentFlags().StringSlice("aws-secret", defaultAwsSmSecrets, "AWS Secrets Manager secret name")
+	err = viper.BindPFlag(core.OptStr_AWS_SecretManager, exportCmd.PersistentFlags().Lookup("aws-secret"))
+	if err != nil {
+		panic(err)
+	}
+
+	rootCmd.AddCommand(exportCmd)
+}
+
+// Top level logic for the export CLI subcommand
+func export(cmd *cobra.Command, args []string) {
+	// export implies --quiet
+	viper.Set(core.OptStr_Quiet, true)
+
+	if countRemoteTargets() == 0 {
+		core.PrintFatal("no remote values to fetch were specified", 1)
+	}
+
+	variables := make(map[string]*variable.Variable, 0)
+	variables = fetchAwsSsmParameters(variables)
+	variables = fetchAwsSmSecrets(variables)
+
+	formattedOutput, err := variable.VariablesAsShellExport(variables)
+	if err != nil {
+		core.PrintFatal("failed to format variables as shell exports", 1)
+	}
+
+	// Display formatted results to STDOUT.
+	core.PrintAlways(formattedOutput)
+}

--- a/cmd/labrador/fetch.go
+++ b/cmd/labrador/fetch.go
@@ -39,14 +39,6 @@ func init() {
 		panic(err)
 	}
 
-	// export
-	defaultExport := viper.GetBool(core.OptStr_Export)
-	fetchCmd.PersistentFlags().Bool("export", defaultExport, "Format as sh environment variables to use with 'source'")
-	err = viper.BindPFlag(core.OptStr_Export, fetchCmd.PersistentFlags().Lookup("export"))
-	if err != nil {
-		panic(err)
-	}
-
 	// quote
 	defaultQuote := viper.GetBool(core.OptStr_Quote)
 	fetchCmd.PersistentFlags().Bool("quote", defaultQuote, "Surround each value with doublequotes")
@@ -84,11 +76,6 @@ func init() {
 
 // Top level logic for the fetch CLI subcommand
 func fetch(cmd *cobra.Command, args []string) {
-	// --export implies --quiet
-	if viper.GetBool(core.OptStr_Export) {
-		viper.Set(core.OptStr_Quiet, true)
-	}
-
 	ShowBanner()
 
 	if countRemoteTargets() == 0 {
@@ -123,19 +110,10 @@ func formatVariablesOutput(variables map[string]*variable.Variable) string {
 	var formattedOutput string
 	var err error
 
-	asExport := viper.GetBool(core.OptStr_Export)
-
-	if asExport {
-		formattedOutput, err = variable.VariablesAsShellExport(variables)
-		if err != nil {
-			core.PrintFatal("failed to format variables as shell exports", 1)
-		}
-	} else {
-		useQuotes := viper.GetBool(core.OptStr_Quote)
-		formattedOutput, err = variable.VariablesAsEnvFile(variables, useQuotes)
-		if err != nil {
-			core.PrintFatal("failed to format variables as env file", 1)
-		}
+	useQuotes := viper.GetBool(core.OptStr_Quote)
+	formattedOutput, err = variable.VariablesAsEnvFile(variables, useQuotes)
+	if err != nil {
+		core.PrintFatal("failed to format variables as env file", 1)
 	}
 
 	return formattedOutput

--- a/cmd/labrador/fetch.go
+++ b/cmd/labrador/fetch.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/divergentcodes/labrador/internal/aws"
 	"github.com/divergentcodes/labrador/internal/core"
 	"github.com/divergentcodes/labrador/internal/variable"
 )
@@ -117,66 +116,6 @@ func fetch(cmd *cobra.Command, args []string) {
 		core.PrintAlways(formattedOutput)
 		core.PrintNormal("\n")
 	}
-}
-
-// Count the number of user-defined resources to pull values from.
-func countRemoteTargets() int {
-	remoteTargetCount := 0
-
-	awsSsmParameters := viper.GetStringSlice(core.OptStr_AWS_SsmParameterStore)
-	remoteTargetCount += len(awsSsmParameters)
-
-	awsSmSecrets := viper.GetStringSlice(core.OptStr_AWS_SecretManager)
-	remoteTargetCount += len(awsSmSecrets)
-
-	return remoteTargetCount
-}
-
-// Fetch AWS SSM Parameter Store values, convert to variables, add to list, and return the list.
-func fetchAwsSsmParameters(variables map[string]*variable.Variable) map[string]*variable.Variable {
-
-	awsSsmParameters := viper.GetStringSlice(core.OptStr_AWS_SsmParameterStore)
-	if len(awsSsmParameters) != 0 {
-		ssmVariables, err := aws.FetchParameterStore()
-		if err != nil {
-			core.PrintFatal("failed to get SSM parameters", 1)
-		}
-
-		core.PrintVerbose(fmt.Sprintf("\nFetched %d values from AWS SSM Parameter Store", len(ssmVariables)))
-		for name, variable := range ssmVariables {
-			variables[name] = variable
-			core.PrintVerbose(fmt.Sprintf("\n\t%s", variable.Metadata["arn"]))
-			core.PrintDebug(fmt.Sprintf("\n\t\ttype: \t\t%s", variable.Metadata["type"]))
-			core.PrintDebug(fmt.Sprintf("\n\t\tversion: \t%s", variable.Metadata["version"]))
-			core.PrintDebug(fmt.Sprintf("\n\t\tmodified: \t%s", variable.Metadata["last-modified"]))
-		}
-	}
-
-	return variables
-}
-
-// Fetch AWS Secrets Manager values, convert to variables, add to list, and return the list.
-func fetchAwsSmSecrets(variables map[string]*variable.Variable) map[string]*variable.Variable {
-
-	awsSmSecrets := viper.GetStringSlice(core.OptStr_AWS_SecretManager)
-	if len(awsSmSecrets) != 0 {
-		smVariables, err := aws.FetchSecretsManager()
-		if err != nil {
-			core.PrintFatal("failed to get Secrets Manager values", 1)
-		}
-
-		core.PrintVerbose(fmt.Sprintf("\nFetched %d values from AWS Secrets Manager", len(smVariables)))
-		for name, variable := range smVariables {
-			variables[name] = variable
-			core.PrintVerbose(fmt.Sprintf("\n\t%s (%s)", variable.Metadata["arn"], variable.Key))
-			core.PrintDebug(fmt.Sprintf("\n\t\tsecret-name: \t%s", variable.Metadata["secret-name"]))
-			core.PrintDebug(fmt.Sprintf("\n\t\ttype: \t\t%s", variable.Metadata["type"]))
-			core.PrintDebug(fmt.Sprintf("\n\t\tversion-id: \t%s", variable.Metadata["version-id"]))
-			core.PrintDebug(fmt.Sprintf("\n\t\tcreated: \t%s", variable.Metadata["created-date"]))
-		}
-	}
-
-	return variables
 }
 
 // Convert the list of variables to formatted output.

--- a/cmd/labrador/root.go
+++ b/cmd/labrador/root.go
@@ -36,7 +36,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/divergentcodes/labrador/internal/aws"
 	"github.com/divergentcodes/labrador/internal/core"
+	"github.com/divergentcodes/labrador/internal/variable"
 )
 
 var (
@@ -129,4 +131,64 @@ func ShowBanner() {
 
 func bannerText() string {
 	return fmt.Sprintf("Labrador %s created by %s <%s>\n", core.Version, core.AuthorName, core.AuthorEmail)
+}
+
+// Count the number of user-defined resources to pull values from.
+func countRemoteTargets() int {
+	remoteTargetCount := 0
+
+	awsSsmParameters := viper.GetStringSlice(core.OptStr_AWS_SsmParameterStore)
+	remoteTargetCount += len(awsSsmParameters)
+
+	awsSmSecrets := viper.GetStringSlice(core.OptStr_AWS_SecretManager)
+	remoteTargetCount += len(awsSmSecrets)
+
+	return remoteTargetCount
+}
+
+// Fetch AWS SSM Parameter Store values, convert to variables, add to list, and return the list.
+func fetchAwsSsmParameters(variables map[string]*variable.Variable) map[string]*variable.Variable {
+
+	awsSsmParameters := viper.GetStringSlice(core.OptStr_AWS_SsmParameterStore)
+	if len(awsSsmParameters) != 0 {
+		ssmVariables, err := aws.FetchParameterStore()
+		if err != nil {
+			core.PrintFatal("failed to get SSM parameters", 1)
+		}
+
+		core.PrintVerbose(fmt.Sprintf("\nFetched %d values from AWS SSM Parameter Store", len(ssmVariables)))
+		for name, variable := range ssmVariables {
+			variables[name] = variable
+			core.PrintVerbose(fmt.Sprintf("\n\t%s", variable.Metadata["arn"]))
+			core.PrintDebug(fmt.Sprintf("\n\t\ttype: \t\t%s", variable.Metadata["type"]))
+			core.PrintDebug(fmt.Sprintf("\n\t\tversion: \t%s", variable.Metadata["version"]))
+			core.PrintDebug(fmt.Sprintf("\n\t\tmodified: \t%s", variable.Metadata["last-modified"]))
+		}
+	}
+
+	return variables
+}
+
+// Fetch AWS Secrets Manager values, convert to variables, add to list, and return the list.
+func fetchAwsSmSecrets(variables map[string]*variable.Variable) map[string]*variable.Variable {
+
+	awsSmSecrets := viper.GetStringSlice(core.OptStr_AWS_SecretManager)
+	if len(awsSmSecrets) != 0 {
+		smVariables, err := aws.FetchSecretsManager()
+		if err != nil {
+			core.PrintFatal("failed to get Secrets Manager values", 1)
+		}
+
+		core.PrintVerbose(fmt.Sprintf("\nFetched %d values from AWS Secrets Manager", len(smVariables)))
+		for name, variable := range smVariables {
+			variables[name] = variable
+			core.PrintVerbose(fmt.Sprintf("\n\t%s (%s)", variable.Metadata["arn"], variable.Key))
+			core.PrintDebug(fmt.Sprintf("\n\t\tsecret-name: \t%s", variable.Metadata["secret-name"]))
+			core.PrintDebug(fmt.Sprintf("\n\t\ttype: \t\t%s", variable.Metadata["type"]))
+			core.PrintDebug(fmt.Sprintf("\n\t\tversion-id: \t%s", variable.Metadata["version-id"]))
+			core.PrintDebug(fmt.Sprintf("\n\t\tcreated: \t%s", variable.Metadata["created-date"]))
+		}
+	}
+
+	return variables
 }

--- a/cmd/labrador/root.go
+++ b/cmd/labrador/root.go
@@ -14,6 +14,7 @@ Usage:
 Available Commands:
 
 	completion  Generate the autocompletion script for the specified shell
+	export      Fetch and export values as shell environment variables
 	fetch       Fetch values from services
 	help        Help about any command
 	version     Print the version

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -48,7 +48,6 @@ var (
 	OptStr_NoConflict = "no-conflict"
 	OptStr_OutFile    = "outfile.path"
 	OptStr_FileMode   = "outfile.mode"
-	OptStr_Export     = "export"
 	OptStr_Quote      = "quote"
 )
 
@@ -62,7 +61,6 @@ func initFetchDefaults() {
 	viper.SetDefault(OptStr_NoConflict, false)
 	viper.SetDefault(OptStr_OutFile, "")
 	viper.SetDefault(OptStr_FileMode, "0600")
-	viper.SetDefault(OptStr_Export, false)
 	viper.SetDefault(OptStr_Quote, false)
 }
 

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -41,6 +41,7 @@ var (
 	OptStr_NoConflict = "no-conflict"
 	OptStr_OutFile    = "outfile.path"
 	OptStr_FileMode   = "outfile.mode"
+	OptStr_Export     = "export"
 	OptStr_Quote      = "quote"
 
 	OptStr_AWS_Region            = "aws.region"
@@ -52,6 +53,7 @@ func initFetchDefaults() {
 	viper.SetDefault(OptStr_NoConflict, false)
 	viper.SetDefault(OptStr_OutFile, "")
 	viper.SetDefault(OptStr_FileMode, "0600")
+	viper.SetDefault(OptStr_Export, false)
 	viper.SetDefault(OptStr_Quote, false)
 
 	viper.SetDefault(OptStr_AWS_Region, nil)

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -10,8 +10,8 @@ import (
 // InitConfigDefaults intializes the default configuration settings for the program.
 func InitConfigDefaults() {
 	initRootDefaults()
+	initValueStoreDefaults()
 	initFetchDefaults()
-
 }
 
 func InitConfigInstance() {
@@ -36,6 +36,13 @@ func initRootDefaults() {
 	viper.SetDefault(OptStr_Verbose, false)
 }
 
+// Value store configuration options.
+var (
+	OptStr_AWS_Region            = "aws.region"
+	OptStr_AWS_SsmParameterStore = "aws.ssm_param"
+	OptStr_AWS_SecretManager     = "aws.sm_secret" //#nosec
+)
+
 // Fetch configuration options
 var (
 	OptStr_NoConflict = "no-conflict"
@@ -43,11 +50,13 @@ var (
 	OptStr_FileMode   = "outfile.mode"
 	OptStr_Export     = "export"
 	OptStr_Quote      = "quote"
-
-	OptStr_AWS_Region            = "aws.region"
-	OptStr_AWS_SsmParameterStore = "aws.ssm_param"
-	OptStr_AWS_SecretManager     = "aws.sm_secret" //#nosec
 )
+
+func initValueStoreDefaults() {
+	viper.SetDefault(OptStr_AWS_Region, nil)
+	viper.SetDefault(OptStr_AWS_SsmParameterStore, nil)
+	viper.SetDefault(OptStr_AWS_SecretManager, nil)
+}
 
 func initFetchDefaults() {
 	viper.SetDefault(OptStr_NoConflict, false)
@@ -55,10 +64,6 @@ func initFetchDefaults() {
 	viper.SetDefault(OptStr_FileMode, "0600")
 	viper.SetDefault(OptStr_Export, false)
 	viper.SetDefault(OptStr_Quote, false)
-
-	viper.SetDefault(OptStr_AWS_Region, nil)
-	viper.SetDefault(OptStr_AWS_SsmParameterStore, nil)
-	viper.SetDefault(OptStr_AWS_SecretManager, nil)
 }
 
 // Configuration file instance setup.

--- a/internal/variable/formats.go
+++ b/internal/variable/formats.go
@@ -4,12 +4,11 @@ package variable
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
 // Format a set of variables as an env file.
-//
-//	export $(labrador --quiet | xargs)
 func VariablesAsEnvFile(variables map[string]*Variable, quote bool) (string, error) {
 
 	result := ""
@@ -19,10 +18,27 @@ func VariablesAsEnvFile(variables map[string]*Variable, quote bool) (string, err
 		envVarValue := item.Value
 		if quote {
 			envVarValue = escapeDoubleQuotes(envVarValue)
-			envVarValue = fmt.Sprintf("\"%s\"\n", envVarValue)
+			envVarValue = fmt.Sprintf("\"%s\"", envVarValue)
 		}
-		result += fmt.Sprintf("%s=%s", envVarName, envVarValue)
+		result += fmt.Sprintf("%s=%s\n", envVarName, envVarValue)
 	}
+	result = strings.TrimSuffix(result, "\n")
+
+	return result, nil
+}
+
+// Format a set of shell environment variable exports.
+//
+// source <(labrador fetch --export)
+func VariablesAsShellExport(variables map[string]*Variable) (string, error) {
+
+	result, err := VariablesAsEnvFile(variables, true)
+	if err != nil {
+		return "", err
+	}
+
+	re := regexp.MustCompile(`(?m)^`)
+	result = re.ReplaceAllString(result, "export ")
 
 	return result, nil
 }


### PR DESCRIPTION
- Add the `export` subcommand for setting environment variables in the current shell.
- Update the README with better examples.