### PR TITLE
feat: add --upper and --lower flags

### DIFF
--- a/.labrador.example.yaml
+++ b/.labrador.example.yaml
@@ -1,7 +1,7 @@
 # .labrador.example.yaml - Example Labrador configuration file.
 
 ###########################################################
-# Output options
+# Display options
 ###########################################################
 
 # Highly detailed debug output. Includes verbose.
@@ -13,13 +13,24 @@ verbose: true
 # Only show the final result, without the banner or info.
 quiet: false
 
-# Surround values in double quotes and escape existing double quotes.
-quote: false
+
+###########################################################
+# Output options
+###########################################################
+
+# Variable key/value transformation options.
+transform:
+  # Surround values in double quotes and escape existing double quotes.
+  quote: false
+  # Make all variable names lower case.
+  lower: false
+  # Make all variable names upper case.
+  upper: false
 
 # Option to write gathered variables/values to a file.
 outfile:
   # File path.
-  path: local.env
+  path: .env
   # File permisson mode.
   mode: '660'
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ any other arguments needed.
   development, pipelines, and deployed environments.
 - **Output options**: Use fetched values to create an `.env` file, set
   environment variables directly in the current shell, pass to another command,
-  or print to the console.
+  or print to the console. Key/value transforms include converting variable names
+  to upper or lower case, and wrapping values in double quotes.
 - **Wildcard paths**: For supported value stores, use a single wildcard resource
   path to recursively load all child values into the workflow
   ([example](#fetch-multiple-values-from-ssm-parameter-store-using-wildcard-paths)).

--- a/cmd/labrador/export.go
+++ b/cmd/labrador/export.go
@@ -15,33 +15,8 @@ var exportCmd = &cobra.Command{
 	Run:   export,
 }
 
-// Initialize the fetch CLI subcommand
+// Initialize the export CLI subcommand
 func init() {
-
-	// aws-region
-	defaultAwsRegion := ""
-	exportCmd.PersistentFlags().String("aws-region", defaultAwsRegion, "AWS region")
-	err := viper.BindPFlag(core.OptStr_AWS_Region, exportCmd.PersistentFlags().Lookup("aws-region"))
-	if err != nil {
-		panic(err)
-	}
-
-	// aws-param
-	defaultAwsSsmParameters := viper.GetViper().GetStringSlice(core.OptStr_AWS_SsmParameterStore)
-	exportCmd.PersistentFlags().StringSlice("aws-param", defaultAwsSsmParameters, "AWS SSM parameter store path prefix")
-	err = viper.BindPFlag(core.OptStr_AWS_SsmParameterStore, exportCmd.PersistentFlags().Lookup("aws-param"))
-	if err != nil {
-		panic(err)
-	}
-
-	// aws-secret
-	defaultAwsSmSecrets := viper.GetViper().GetStringSlice(core.OptStr_AWS_SecretManager)
-	exportCmd.PersistentFlags().StringSlice("aws-secret", defaultAwsSmSecrets, "AWS Secrets Manager secret name")
-	err = viper.BindPFlag(core.OptStr_AWS_SecretManager, exportCmd.PersistentFlags().Lookup("aws-secret"))
-	if err != nil {
-		panic(err)
-	}
-
 	rootCmd.AddCommand(exportCmd)
 }
 
@@ -58,7 +33,9 @@ func export(cmd *cobra.Command, args []string) {
 	variables = fetchAwsSsmParameters(variables)
 	variables = fetchAwsSmSecrets(variables)
 
-	formattedOutput, err := variable.VariablesAsShellExport(variables)
+	toLower := viper.GetBool(core.OptStr_ToLower)
+	toUpper := viper.GetBool(core.OptStr_ToUpper)
+	formattedOutput, err := variable.VariablesAsShellExport(variables, toLower, toUpper)
 	if err != nil {
 		core.PrintFatal("failed to format variables as shell exports", 1)
 	}

--- a/cmd/labrador/fetch.go
+++ b/cmd/labrador/fetch.go
@@ -23,6 +23,17 @@ var fetchCmd = &cobra.Command{
 // Initialize the fetch CLI subcommand
 func init() {
 
+	// json
+	// TODO: implement exporting results to JSON.
+	/*
+		defaultOutJSON := viper.GetBool(core.OptStr_OutJSON)
+		rootCmd.PersistentFlags().Bool("json", defaultOutJSON, "Use JSON output")
+		err = viper.BindPFlag(core.OptStr_OutJSON, rootCmd.PersistentFlags().Lookup("json"))
+		if err != nil {
+			panic(err)
+		}
+	*/
+
 	// outfile
 	defaultOutFile := viper.GetViper().GetString(core.OptStr_OutFile)
 	fetchCmd.PersistentFlags().StringP("outfile", "o", defaultOutFile, "File path to write variable/value pairs to")
@@ -35,38 +46,6 @@ func init() {
 	defaultFileMode := viper.GetViper().GetString(core.OptStr_FileMode)
 	fetchCmd.PersistentFlags().String("outfile-mode", defaultFileMode, "File permissions for newly created outfile")
 	err = viper.BindPFlag(core.OptStr_FileMode, fetchCmd.PersistentFlags().Lookup("outfile-mode"))
-	if err != nil {
-		panic(err)
-	}
-
-	// quote
-	defaultQuote := viper.GetBool(core.OptStr_Quote)
-	fetchCmd.PersistentFlags().Bool("quote", defaultQuote, "Surround each value with doublequotes")
-	err = viper.BindPFlag(core.OptStr_Quote, fetchCmd.PersistentFlags().Lookup("quote"))
-	if err != nil {
-		panic(err)
-	}
-
-	// aws-region
-	defaultAwsRegion := ""
-	fetchCmd.PersistentFlags().String("aws-region", defaultAwsRegion, "AWS region")
-	err = viper.BindPFlag(core.OptStr_AWS_Region, fetchCmd.PersistentFlags().Lookup("aws-region"))
-	if err != nil {
-		panic(err)
-	}
-
-	// aws-param
-	defaultAwsSsmParameters := viper.GetViper().GetStringSlice(core.OptStr_AWS_SsmParameterStore)
-	fetchCmd.PersistentFlags().StringSlice("aws-param", defaultAwsSsmParameters, "AWS SSM parameter store path prefix")
-	err = viper.BindPFlag(core.OptStr_AWS_SsmParameterStore, fetchCmd.PersistentFlags().Lookup("aws-param"))
-	if err != nil {
-		panic(err)
-	}
-
-	// aws-secret
-	defaultAwsSmSecrets := viper.GetViper().GetStringSlice(core.OptStr_AWS_SecretManager)
-	fetchCmd.PersistentFlags().StringSlice("aws-secret", defaultAwsSmSecrets, "AWS Secrets Manager secret name")
-	err = viper.BindPFlag(core.OptStr_AWS_SecretManager, fetchCmd.PersistentFlags().Lookup("aws-secret"))
 	if err != nil {
 		panic(err)
 	}
@@ -111,7 +90,10 @@ func formatVariablesOutput(variables map[string]*variable.Variable) string {
 	var err error
 
 	useQuotes := viper.GetBool(core.OptStr_Quote)
-	formattedOutput, err = variable.VariablesAsEnvFile(variables, useQuotes)
+	toLower := viper.GetBool(core.OptStr_ToLower)
+	toUpper := viper.GetBool(core.OptStr_ToUpper)
+
+	formattedOutput, err = variable.VariablesAsEnvFile(variables, useQuotes, toLower, toUpper)
 	if err != nil {
 		core.PrintFatal("failed to format variables as env file", 1)
 	}

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -11,6 +11,7 @@ import (
 func InitConfigDefaults() {
 	initRootDefaults()
 	initValueStoreDefaults()
+	initOutputTransformOptions()
 	initFetchDefaults()
 }
 
@@ -43,12 +44,18 @@ var (
 	OptStr_AWS_SecretManager     = "aws.sm_secret" //#nosec
 )
 
+// Variable key/value transformation configuration options
+var (
+	OptStr_Quote   = "transform.quote"
+	OptStr_ToLower = "transform.lower"
+	OptStr_ToUpper = "transform.upper"
+)
+
 // Fetch configuration options
 var (
 	OptStr_NoConflict = "no-conflict"
 	OptStr_OutFile    = "outfile.path"
 	OptStr_FileMode   = "outfile.mode"
-	OptStr_Quote      = "quote"
 )
 
 func initValueStoreDefaults() {
@@ -57,11 +64,16 @@ func initValueStoreDefaults() {
 	viper.SetDefault(OptStr_AWS_SecretManager, nil)
 }
 
+func initOutputTransformOptions() {
+	viper.SetDefault(OptStr_Quote, false)
+	viper.SetDefault(OptStr_ToLower, false)
+	viper.SetDefault(OptStr_ToUpper, false)
+}
+
 func initFetchDefaults() {
 	viper.SetDefault(OptStr_NoConflict, false)
 	viper.SetDefault(OptStr_OutFile, "")
 	viper.SetDefault(OptStr_FileMode, "0600")
-	viper.SetDefault(OptStr_Quote, false)
 }
 
 // Configuration file instance setup.

--- a/internal/variable/formats.go
+++ b/internal/variable/formats.go
@@ -9,17 +9,24 @@ import (
 )
 
 // Format a set of variables as an env file.
-func VariablesAsEnvFile(variables map[string]*Variable, quote bool) (string, error) {
+func VariablesAsEnvFile(variables map[string]*Variable, quote bool, lower bool, upper bool) (string, error) {
 
 	result := ""
 
 	for name, item := range variables {
 		envVarName := envNamify(name)
+		if lower {
+			envVarName = strings.ToLower(envVarName)
+		} else if upper {
+			envVarName = strings.ToUpper(envVarName)
+		}
+
 		envVarValue := item.Value
 		if quote {
 			envVarValue = escapeDoubleQuotes(envVarValue)
 			envVarValue = fmt.Sprintf("\"%s\"", envVarValue)
 		}
+
 		result += fmt.Sprintf("%s=%s\n", envVarName, envVarValue)
 	}
 	result = strings.TrimSuffix(result, "\n")
@@ -29,10 +36,10 @@ func VariablesAsEnvFile(variables map[string]*Variable, quote bool) (string, err
 
 // Format a set of shell environment variable exports.
 //
-// source <(labrador fetch --export)
-func VariablesAsShellExport(variables map[string]*Variable) (string, error) {
+// source <(labrador export)
+func VariablesAsShellExport(variables map[string]*Variable, lower bool, upper bool) (string, error) {
 
-	result, err := VariablesAsEnvFile(variables, true)
+	result, err := VariablesAsEnvFile(variables, true, lower, upper)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
- Add `--upper` and `--lower` flags to transform variable names to upper or lower case.
- Make remote service parameters part of the root command, for reuse across subcommands.